### PR TITLE
use pwiki for dosage info if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 gem 'rack-cors'
 gem 'rails', '~> 5.0.1'
+
 gem 'RecastAI'
 
 group :test do

--- a/app/models/dose_info.rb
+++ b/app/models/dose_info.rb
@@ -11,61 +11,56 @@ class DoseInfo < ApplicationRecord
   end
 
   def insufflation_dose_string
-    insufflation_doses = []
-    insufflation_doses << threshold_insufflation_dose_string
-    insufflation_doses << light_insufflation_dose_string
-    insufflation_doses << common_insufflation_dose_string
-    insufflation_doses << strong_insufflation_dose_string
-    insufflation_doses << heavy_insufflation_dose_string
     return nil if insufflation_doses.compact.empty?
     "Insufflation (snorting) doses: #{insufflation_doses.compact.join(' | ')}"
   end
 
   def oral_dose_string
-    oral_doses = []
-    oral_doses << threshold_oral_dose_string
-    oral_doses << light_oral_dose_string
-    oral_doses << common_oral_dose_string
-    oral_doses << strong_oral_dose_string
-    oral_doses << heavy_oral_dose_string
     return nil if oral_doses.compact.empty?
     "Oral doses: #{oral_doses.compact.join(' | ')}"
   end
 
   def intravenous_dose_string
-    intravenous_doses = []
-    intravenous_doses << threshold_intravenous_dose_string
-    intravenous_doses << light_intravenous_dose_string
-    intravenous_doses << common_intravenous_dose_string
-    intravenous_doses << strong_intravenous_dose_string
-    intravenous_doses << heavy_intravenous_dose_string
     return nil if intravenous_doses.compact.empty?
     "Intravenous doses: #{intravenous_doses.compact.join(' | ')}"
   end
 
   def smoked_dose_string
-    smoked_doses = []
-    smoked_doses << threshold_smoked_dose_string
-    smoked_doses << light_smoked_dose_string
-    smoked_doses << common_smoked_dose_string
-    smoked_doses << strong_smoked_dose_string
-    smoked_doses << heavy_smoked_dose_string
     return nil if smoked_doses.compact.empty?
     "Smoking doses: #{smoked_doses.compact.join(' | ')}"
   end
 
   def sublingual_dose_string
-    sublingual_doses = []
-    sublingual_doses << threshold_sublingual_dose_string
-    sublingual_doses << light_sublingual_dose_string
-    sublingual_doses << common_sublingual_dose_string
-    sublingual_doses << strong_sublingual_dose_string
-    sublingual_doses << heavy_sublingual_dose_string
     return nil if sublingual_doses.compact.empty?
     "Sublingual doses: #{sublingual_doses.compact.join(' | ')}"
   end
 
   private
+
+  def insufflation_doses
+    [threshold_insufflation_dose_string, light_insufflation_dose_string, common_insufflation_dose_string,
+     strong_insufflation_dose_string, heavy_insufflation_dose_string]
+  end
+
+  def oral_doses
+    [threshold_oral_dose_string, light_oral_dose_string, common_oral_dose_string,
+     strong_oral_dose_string, heavy_oral_dose_string]
+  end
+
+  def intravenous_doses
+    [threshold_intravenous_dose_string, light_intravenous_dose_string, common_intravenous_dose_string,
+     strong_intravenous_dose_string, heavy_intravenous_dose_string]
+  end
+
+  def smoked_doses
+    [threshold_smoked_dose_string, light_smoked_dose_string, common_smoked_dose_string,
+     strong_smoked_dose_string, heavy_smoked_dose_string]
+  end
+
+  def sublingual_doses
+    [threshold_sublingual_dose_string, light_sublingual_dose_string, common_sublingual_dose_string,
+     strong_sublingual_dose_string, heavy_sublingual_dose_string]
+  end
 
   def threshold_insufflation_dose_string
     return nil unless insufflated_threshold_dose

--- a/app/models/dose_info.rb
+++ b/app/models/dose_info.rb
@@ -1,0 +1,209 @@
+class DoseInfo < ApplicationRecord
+  belongs_to :drug
+
+  def info_string
+    info_strings = [insufflation_dose_string, oral_dose_string, smoked_dose_string,
+                    intravenous_dose_string, sublingual_dose_string].compact
+    return nil if info_strings.empty?
+    string = "We have the following dose information for #{drug.name}. "
+    string += info_strings.join('. ') + '.'
+    string
+  end
+
+  def insufflation_dose_string
+    insufflation_doses = []
+    insufflation_doses << threshold_insufflation_dose_string
+    insufflation_doses << light_insufflation_dose_string
+    insufflation_doses << common_insufflation_dose_string
+    insufflation_doses << strong_insufflation_dose_string
+    insufflation_doses << heavy_insufflation_dose_string
+    return nil if insufflation_doses.compact.empty?
+    "Insufflation (snorting) doses: #{insufflation_doses.compact.join(' | ')}"
+  end
+
+  def oral_dose_string
+    oral_doses = []
+    oral_doses << threshold_oral_dose_string
+    oral_doses << light_oral_dose_string
+    oral_doses << common_oral_dose_string
+    oral_doses << strong_oral_dose_string
+    oral_doses << heavy_oral_dose_string
+    return nil if oral_doses.compact.empty?
+    "Oral doses: #{oral_doses.compact.join(' | ')}"
+  end
+
+  def intravenous_dose_string
+    intravenous_doses = []
+    intravenous_doses << threshold_intravenous_dose_string
+    intravenous_doses << light_intravenous_dose_string
+    intravenous_doses << common_intravenous_dose_string
+    intravenous_doses << strong_intravenous_dose_string
+    intravenous_doses << heavy_intravenous_dose_string
+    return nil if intravenous_doses.compact.empty?
+    "Intravenous doses: #{intravenous_doses.compact.join(' | ')}"
+  end
+
+  def smoked_dose_string
+    smoked_doses = []
+    smoked_doses << threshold_smoked_dose_string
+    smoked_doses << light_smoked_dose_string
+    smoked_doses << common_smoked_dose_string
+    smoked_doses << strong_smoked_dose_string
+    smoked_doses << heavy_smoked_dose_string
+    return nil if smoked_doses.compact.empty?
+    "Smoking doses: #{smoked_doses.compact.join(' | ')}"
+  end
+
+  def sublingual_dose_string
+    sublingual_doses = []
+    sublingual_doses << threshold_sublingual_dose_string
+    sublingual_doses << light_sublingual_dose_string
+    sublingual_doses << common_sublingual_dose_string
+    sublingual_doses << strong_sublingual_dose_string
+    sublingual_doses << heavy_sublingual_dose_string
+    return nil if sublingual_doses.compact.empty?
+    "Sublingual doses: #{sublingual_doses.compact.join(' | ')}"
+  end
+
+  private
+
+  def threshold_insufflation_dose_string
+    return nil unless insufflated_threshold_dose
+    "Threshold dose: #{insufflated_threshold_dose}#{insufflated_dose_units}"
+  end
+
+  def light_insufflation_dose_string
+    return nil unless insufflated_min_light_dose || insufflated_max_light_dose
+    "Light dose: #{insufflated_min_light_dose}#{insufflated_dose_units} -"\
+    " #{insufflated_max_light_dose}#{insufflated_dose_units}"
+  end
+
+  def common_insufflation_dose_string
+    return nil unless insufflated_min_common_dose || insufflated_max_common_dose
+    "Common dose: #{insufflated_min_common_dose}#{insufflated_dose_units} -"\
+    " #{insufflated_max_common_dose}#{insufflated_dose_units}"
+  end
+
+  def strong_insufflation_dose_string
+    return nil unless insufflated_min_strong_dose || insufflated_max_strong_dose
+    "Strong dose: #{insufflated_min_strong_dose}#{insufflated_dose_units} -"\
+    " #{insufflated_max_strong_dose}#{insufflated_dose_units}"
+  end
+
+  def heavy_insufflation_dose_string
+    return nil unless insufflated_heavy_dose
+    "Heavy dose: #{insufflated_heavy_dose}#{insufflated_dose_units}"
+  end
+
+  def threshold_oral_dose_string
+    return nil unless oral_threshold_dose
+    "Threshold dose: #{oral_threshold_dose}#{oral_dose_units}"
+  end
+
+  def light_oral_dose_string
+    return nil unless oral_min_light_dose || oral_max_light_dose
+    "Light dose: #{oral_min_light_dose}#{oral_dose_units} -"\
+    " #{oral_max_light_dose}#{oral_dose_units}"
+  end
+
+  def common_oral_dose_string
+    return nil unless oral_min_common_dose || oral_max_common_dose
+    "Common dose: #{oral_min_common_dose}#{oral_dose_units} -"\
+    " #{oral_max_common_dose}#{oral_dose_units}"
+  end
+
+  def strong_oral_dose_string
+    return nil unless oral_min_strong_dose || oral_max_strong_dose
+    "Strong dose: #{oral_min_strong_dose}#{oral_dose_units} -"\
+    " #{oral_max_strong_dose}#{oral_dose_units}"
+  end
+
+  def heavy_oral_dose_string
+    return nil unless oral_heavy_dose
+    "Heavy dose: #{oral_heavy_dose}#{oral_dose_units}"
+  end
+
+  def threshold_smoked_dose_string
+    return nil unless smoked_threshold_dose
+    "Threshold dose: #{smoked_threshold_dose}#{smoked_dose_units}"
+  end
+
+  def light_smoked_dose_string
+    return nil unless smoked_min_light_dose || smoked_max_light_dose
+    "Light dose: #{smoked_min_light_dose}#{smoked_dose_units} -"\
+    " #{smoked_max_light_dose}#{smoked_dose_units}"
+  end
+
+  def common_smoked_dose_string
+    return nil unless smoked_min_common_dose || smoked_max_common_dose
+    "Common dose: #{smoked_min_common_dose}#{smoked_dose_units} -"\
+    " #{smoked_max_common_dose}#{smoked_dose_units}"
+  end
+
+  def strong_smoked_dose_string
+    return nil unless smoked_min_strong_dose || smoked_max_strong_dose
+    "Strong dose: #{smoked_min_strong_dose}#{smoked_dose_units} -"\
+    " #{smoked_max_strong_dose}#{smoked_dose_units}"
+  end
+
+  def heavy_smoked_dose_string
+    return nil unless smoked_heavy_dose
+    "Heavy dose: #{smoked_heavy_dose}#{smoked_dose_units}"
+  end
+
+  def threshold_sublingual_dose_string
+    return nil unless sublingual_threshold_dose
+    "Threshold dose: #{sublingual_threshold_dose}#{sublingual_dose_units}"
+  end
+
+  def light_sublingual_dose_string
+    return nil unless sublingual_min_light_dose || sublingual_max_light_dose
+    "Light dose: #{sublingual_min_light_dose}#{sublingual_dose_units} -"\
+    " #{sublingual_max_light_dose}#{sublingual_dose_units}"
+  end
+
+  def common_sublingual_dose_string
+    return nil unless sublingual_min_common_dose || sublingual_max_common_dose
+    "Common dose: #{sublingual_min_common_dose}#{sublingual_dose_units} -"\
+    " #{sublingual_max_common_dose}#{sublingual_dose_units}"
+  end
+
+  def strong_sublingual_dose_string
+    return nil unless sublingual_min_strong_dose || sublingual_max_strong_dose
+    "Strong dose: #{sublingual_min_strong_dose}#{sublingual_dose_units} -"\
+    " #{sublingual_max_strong_dose}#{sublingual_dose_units}"
+  end
+
+  def heavy_sublingual_dose_string
+    return nil unless sublingual_heavy_dose
+    "Heavy dose: #{sublingual_heavy_dose}#{sublingual_dose_units}"
+  end
+
+  def threshold_intravenous_dose_string
+    return nil unless intravenous_threshold_dose
+    "Threshold dose: #{intravenous_threshold_dose}#{intravenous_dose_units}"
+  end
+
+  def light_intravenous_dose_string
+    return nil unless intravenous_min_light_dose || intravenous_max_light_dose
+    "Light dose: #{intravenous_min_light_dose}#{intravenous_dose_units} -"\
+    " #{intravenous_max_light_dose}#{intravenous_dose_units}"
+  end
+
+  def common_intravenous_dose_string
+    return nil unless intravenous_min_common_dose || intravenous_max_common_dose
+    "Common dose: #{intravenous_min_common_dose}#{intravenous_dose_units} -"\
+    " #{intravenous_max_common_dose}#{intravenous_dose_units}"
+  end
+
+  def strong_intravenous_dose_string
+    return nil unless intravenous_min_strong_dose || intravenous_max_strong_dose
+    "Strong dose: #{intravenous_min_strong_dose}#{intravenous_dose_units} -"\
+    " #{intravenous_max_strong_dose}#{intravenous_dose_units}"
+  end
+
+  def heavy_intravenous_dose_string
+    return nil unless intravenous_heavy_dose
+    "Heavy dose: #{intravenous_heavy_dose}#{intravenous_dose_units}"
+  end
+end

--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -1,4 +1,5 @@
 class Drug < ApplicationRecord
+  has_one :dose_info
 
   def self.find_with_aliases(name)
     name = name&.downcase
@@ -27,11 +28,8 @@ class Drug < ApplicationRecord
   end
 
   def dose_profile
-    return "Sorry, we don't have any reported dosing information for #{substance_name}." unless dose_summary
-    summary = "We have the following dose information for #{substance_name}: "
-    summary += dose_summary
-    summary += " Warning note! Avoid #{avoid_info}" if avoid_info
-    summary.gsub('..', '.')
+    return extended_dose_info if dose_info&.info_string
+    basic_dose_info
   end
 
   def effects_profile
@@ -72,6 +70,20 @@ class Drug < ApplicationRecord
   end
 
   private
+
+  def extended_dose_info
+    summary = dose_info.info_string
+    summary += " Warning note! Avoid #{avoid_info}" if avoid_info
+    summary
+  end
+
+  def basic_dose_info
+    return "Sorry, we don't have any reported dosing information for #{substance_name}." unless dose_summary
+    summary = "We have the following dose information for #{substance_name}: "
+    summary += dose_summary
+    summary += " Warning note! Avoid #{avoid_info}" if avoid_info
+    summary.gsub('..', '.')
+  end
 
   def duration_of_effects_string
     profile = "This is the duration information we have for #{substance_name}. "

--- a/db/migrate/20170802170932_create_dose_infos.rb
+++ b/db/migrate/20170802170932_create_dose_infos.rb
@@ -1,0 +1,53 @@
+class CreateDoseInfos < ActiveRecord::Migration[5.0]
+  def change
+    create_table :dose_infos do |t|
+      t.string :insufflated_dose_units
+      t.string :insufflated_heavy_dose
+      t.string :insufflated_max_common_dose
+      t.string :insufflated_max_light_dose
+      t.string :insufflated_max_strong_dose
+      t.string :insufflated_min_common_dose
+      t.string :insufflated_min_light_dose
+      t.string :insufflated_min_strong_dose
+      t.string :insufflated_threshold_dose
+      t.string :intravenous_dose_units
+      t.string :intravenous_heavy_dose
+      t.string :intravenous_max_common_dose
+      t.string :intravenous_max_light_dose
+      t.string :intravenous_max_strong_dose
+      t.string :intravenous_min_common_dose
+      t.string :intravenous_min_light_dose
+      t.string :intravenous_min_strong_dose
+      t.string :intravenous_threshold_dose
+      t.string :oral_dose_units
+      t.string :oral_heavy_dose
+      t.string :oral_max_common_dose
+      t.string :oral_max_light_dose
+      t.string :oral_max_strong_dose
+      t.string :oral_min_common_dose
+      t.string :oral_min_light_dose
+      t.string :oral_min_strong_dose
+      t.string :oral_threshold_dose
+      t.string :sublingual_dose_units
+      t.string :sublingual_heavy_dose
+      t.string :sublingual_max_common_dose
+      t.string :sublingual_max_light_dose
+      t.string :sublingual_max_strong_dose
+      t.string :sublingual_min_common_dose
+      t.string :sublingual_min_light_dose
+      t.string :sublingual_min_strong_dose
+      t.string :sublingual_threshold_dose
+      t.string :smoked_dose_units
+      t.string :smoked_heavy_dose
+      t.string :smoked_max_common_dose
+      t.string :smoked_max_light_dose
+      t.string :smoked_max_strong_dose
+      t.string :smoked_min_common_dose
+      t.string :smoked_min_light_dose
+      t.string :smoked_min_strong_dose
+      t.string :smoked_threshold_dose
+      t.references :drug
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,62 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170709031137) do
+ActiveRecord::Schema.define(version: 20170802170932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "dose_infos", force: :cascade do |t|
+    t.string   "insufflated_dose_units"
+    t.string   "insufflated_heavy_dose"
+    t.string   "insufflated_max_common_dose"
+    t.string   "insufflated_max_light_dose"
+    t.string   "insufflated_max_strong_dose"
+    t.string   "insufflated_min_common_dose"
+    t.string   "insufflated_min_light_dose"
+    t.string   "insufflated_min_strong_dose"
+    t.string   "insufflated_threshold_dose"
+    t.string   "intravenous_dose_units"
+    t.string   "intravenous_heavy_dose"
+    t.string   "intravenous_max_common_dose"
+    t.string   "intravenous_max_light_dose"
+    t.string   "intravenous_max_strong_dose"
+    t.string   "intravenous_min_common_dose"
+    t.string   "intravenous_min_light_dose"
+    t.string   "intravenous_min_strong_dose"
+    t.string   "intravenous_threshold_dose"
+    t.string   "oral_dose_units"
+    t.string   "oral_heavy_dose"
+    t.string   "oral_max_common_dose"
+    t.string   "oral_max_light_dose"
+    t.string   "oral_max_strong_dose"
+    t.string   "oral_min_common_dose"
+    t.string   "oral_min_light_dose"
+    t.string   "oral_min_strong_dose"
+    t.string   "oral_threshold_dose"
+    t.string   "sublingual_dose_units"
+    t.string   "sublingual_heavy_dose"
+    t.string   "sublingual_max_common_dose"
+    t.string   "sublingual_max_light_dose"
+    t.string   "sublingual_max_strong_dose"
+    t.string   "sublingual_min_common_dose"
+    t.string   "sublingual_min_light_dose"
+    t.string   "sublingual_min_strong_dose"
+    t.string   "sublingual_threshold_dose"
+    t.string   "smoked_dose_units"
+    t.string   "smoked_heavy_dose"
+    t.string   "smoked_max_common_dose"
+    t.string   "smoked_max_light_dose"
+    t.string   "smoked_max_strong_dose"
+    t.string   "smoked_min_common_dose"
+    t.string   "smoked_min_light_dose"
+    t.string   "smoked_min_strong_dose"
+    t.string   "smoked_threshold_dose"
+    t.integer  "drug_id"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.index ["drug_id"], name: "index_dose_infos_on_drug_id", using: :btree
+  end
 
   create_table "drugs", force: :cascade do |t|
     t.string   "name"

--- a/lib/tasks/substances.rake
+++ b/lib/tasks/substances.rake
@@ -15,8 +15,8 @@ namespace :substances do
           puts "#{substance} skipped"
         elsif new_substance
           puts "#{substance} updated - fetching more information..."
-          pn_requester = Psychonaut::SubstanceRequester.new(substance: new_substance)
-          puts 'updated info' if pn_requester.add_extra_information
+          pn_requester = Psychonaut::SubstanceRequester.new(substance: new_substance, force: force)
+          puts 'updated info' if pn_requester.write_information_for_substance
         else
           puts "#{substance} not found"
         end

--- a/lib/tripsit.rb
+++ b/lib/tripsit.rb
@@ -7,7 +7,7 @@ module TripSit
   DRUG_INTERACTION_URL = BASE_URL + '/getInteraction'
 
   class SubstanceRequester
-    def initialize(subject:, force: true)
+    def initialize(subject:, force: false)
       @subject = subject
       @force = force
       @name = nil


### PR DESCRIPTION
This creates a separate model for detailed dosage info pulled from Psychonaut Wiki if available and uses the PWiki service to create them.

If detailed dosage information is available, it uses it, otherwise it uses the string from TripSit. In both cases, if there are any strong warnings associated with the substance, it is returned with the dosage information.

